### PR TITLE
Use master branch of Toolbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3347,9 +3347,7 @@
       }
     },
     "feather-icons": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-3.2.2.tgz",
-      "integrity": "sha1-lsEy5KQB1cwYwDBjyHmZ9H3ORCs="
+      "version": "github:iFixit/feather#d5c65134d3a39118e9ae7b860be0a24227331c6a"
     },
     "figures": {
       "version": "1.7.0",
@@ -10178,9 +10176,9 @@
       "dev": true
     },
     "toolbox": {
-      "version": "github:ifixit/toolbox#9356772302f21a509c60103b59c651e3f0caf9fd",
+      "version": "github:ifixit/toolbox#945595e8de31c49c0565493c295759995e1964db",
       "requires": {
-        "feather-icons": "3.2.2",
+        "feather-icons": "github:iFixit/feather#d5c65134d3a39118e9ae7b860be0a24227331c6a",
         "glamor": "2.20.39",
         "glamorous": "4.1.0",
         "prop-types": "15.5.10"

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "formy",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "prop-types": "^15.5.10",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "toolbox": "github:ifixit/toolbox#create-transpiled-build"
-  },
-  "devDependencies": {
-    "react-scripts": "1.0.6"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  },
-  "main": "src/Formy/Form.js"
+   "name": "formy",
+   "version": "1.0.0",
+   "private": true,
+   "dependencies": {
+      "prop-types": "^15.5.10",
+      "react": "^15.5.4",
+      "react-dom": "^15.5.4",
+      "toolbox": "github:ifixit/toolbox"
+   },
+   "devDependencies": {
+      "react-scripts": "1.0.6"
+   },
+   "scripts": {
+      "start": "react-scripts start",
+      "build": "react-scripts build",
+      "test": "react-scripts test --env=jsdom",
+      "eject": "react-scripts eject"
+   },
+   "main": "src/Formy/Form.js"
 }

--- a/src/Formy/FormDefaultComponentLibrary.js
+++ b/src/Formy/FormDefaultComponentLibrary.js
@@ -1,14 +1,14 @@
-import Toolbox from 'toolbox';
+import { TextField, Checkbox, Radio, Textarea, RadioGroup } from 'toolbox';
 
 const FormFieldComponentLibrary = {
-   text: Toolbox.TextField,
-   email: Toolbox.TextField,
-   password: Toolbox.TextField,
-   number: Toolbox.TextField,
-   checkbox: Toolbox.Checkbox,
-   radio: Toolbox.Radio,
-   textarea: Toolbox.Textarea,
-   radiogroup: Toolbox.RadioGroup,
+   text: TextField,
+   email: TextField,
+   password: TextField,
+   number: TextField,
+   checkbox: Checkbox,
+   radio: Radio,
+   textarea: Textarea,
+   radiogroup: RadioGroup,
 };
 
 export default FormFieldComponentLibrary;


### PR DESCRIPTION
Formy now installs the `master` branch of Toolbox. `FormDefaultComponentLibrary.js` has been updated to be compatible with the way Toolbox exports components.

qa_req 0