### PR TITLE
Formy: Update NPM Version to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "formy",
-   "version": "1.0.3",
+   "version": "1.0.4",
    "dependencies": {
       "@ifixit/toolbox": "^0.10.3",
       "enzyme": "^3.3.0",


### PR DESCRIPTION
This pull bumps the `package.json` version from 1.0.3 to 1.0.4.

cr_req 1
qa_req 0