### PR TITLE
package.json: fix main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "formy",
-   "version": "1.0.6",
+   "version": "1.0.7",
    "dependencies": {
       "@ifixit/toolbox": "^1.0.1",
       "enzyme": "^3.3.0",
@@ -23,5 +23,5 @@
       "test": "react-scripts test --env=jsdom",
       "eject": "react-scripts eject"
    },
-   "main": "src/index.js"
+   "main": "src/Formy/Form.js"
 }


### PR DESCRIPTION
Looks like this was accidentally changed in
4eb24a49039bddfbb59bff211cc9dc35db952dde
and has since broken the whole package. yay.