### PR TITLE
Build: only transpile with babel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formy",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
    },
    "scripts": {
       "start": "react-scripts start",
-      "build": "react-scripts build",
+      "build": "babel src/Formy --out-dir dist --extensions \".js,.jsx\"",
       "test": "react-scripts test --env=jsdom",
       "eject": "react-scripts eject"
    },
-   "main": "src/Formy/Form.js"
+   "main": "dist/Form.js"
 }


### PR DESCRIPTION
For the built version, don't pack it with webpack (The react-scripts
default). We don't want to package the whole thing bundled with its
large deps as a black box. We want to let the require-er have control
over the exact versions and de-duping the deps.

Like all our other React library repos, just transpile with
babel and let the parent module deal with webpacking.